### PR TITLE
docs: fix typo in Font.swift comment

### DIFF
--- a/Sources/Figlet/Font.swift
+++ b/Sources/Figlet/Font.swift
@@ -10,7 +10,7 @@
 //
 //===--------------------------------------------------------------------
 
-// This code is take from https://github.com/dfreniche/SwiftFiglet/, license as follows:
+// This code is taken from https://github.com/dfreniche/SwiftFiglet/, license as follows:
 
 /*
 


### PR DESCRIPTION
## Summary

Fix a typo in `Sources/Figlet/Font.swift`:

- Line 13: `take` → `taken` in the attribution comment ("This code is taken from...")

No functional changes — comment only.